### PR TITLE
feat: add Google Video API support for video generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "celeste-core>=0.1.0",
     "replicate>=0.30.0",
+    "google-genai>=0.9.0",
 ]
 
 [dependency-groups]

--- a/src/celeste_video_generation/mapping.py
+++ b/src/celeste_video_generation/mapping.py
@@ -1,0 +1,13 @@
+from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
+
+# Capability for this domain package
+CAPABILITY: Capability = Capability.VIDEO_GENERATION
+
+# Provider wiring for video generation clients
+PROVIDER_MAPPING: dict[Provider, tuple[str, str]] = {
+    Provider.REPLICATE: (".providers.replicate", "ReplicateVideoClient"),
+    Provider.GOOGLE: (".providers.google", "GoogleVideoClient"),
+}
+
+__all__ = ["CAPABILITY", "PROVIDER_MAPPING"]

--- a/src/celeste_video_generation/providers/google.py
+++ b/src/celeste_video_generation/providers/google.py
@@ -1,0 +1,45 @@
+import asyncio
+from typing import Any
+
+from celeste_core import AIResponse, Provider, VideoArtifact
+from celeste_core.base.video_client import BaseVideoClient
+from celeste_core.config.settings import settings
+from celeste_core.enums.capability import Capability
+from google import genai
+
+
+class GoogleVideoClient(BaseVideoClient):
+    def __init__(self, model: str = "veo-3.0-generate-preview", **kwargs: Any) -> None:
+        super().__init__(
+            model=model,
+            capability=Capability.VIDEO_GENERATION,
+            provider=Provider.GOOGLE,
+            **kwargs,
+        )
+        self.client = genai.Client(api_key=settings.google.api_key)
+
+    async def generate_content(
+        self, prompt: str, **kwargs: Any
+    ) -> AIResponse[list[VideoArtifact]]:
+        # Start video generation
+        operation = await self.client.aio.models.generate_videos(
+            model=self.model_name,
+            prompt=prompt,
+        )
+
+        # Poll the operation status until the video is ready
+        while not operation.done:
+            await asyncio.sleep(10)
+            operation = await self.client.aio.operations.get(operation)
+
+        # Get the generated video URI
+        generated_video = operation.response.generated_videos[0]
+        video_url = generated_video.video.uri
+
+        artifacts: list[VideoArtifact] = [VideoArtifact(url=video_url)]
+
+        return AIResponse(
+            content=artifacts,
+            provider=Provider.GOOGLE,
+            metadata={"model": self.model_name},
+        )


### PR DESCRIPTION
## Summary
- Add support for Google's Video API (Veo 3.0) for video generation capabilities
- Implement centralized provider mapping for cleaner and more maintainable architecture
- Refactor module imports to use Python's `importlib` for dynamic loading

## Changes
- **New Google Video Client**: Implemented `GoogleVideoClient` class that integrates with Google's genai SDK
  - Uses `veo-3.0-generate-preview` model by default
  - Handles async video generation with polling mechanism
  - Returns standardized `VideoArtifact` responses

- **Provider Mapping**: Created centralized `mapping.py` module
  - Defines `PROVIDER_MAPPING` dictionary for clean provider-to-client resolution
  - Establishes clear capability designation (`VIDEO_GENERATION`)
  
- **Refactored Imports**: Updated `__init__.py` to use `importlib.import_module`
  - More pythonic approach to dynamic module loading
  - Simplified provider validation logic
  
- **Dependencies**: Added `google-genai>=0.9.0` to project requirements

## Test Plan
- [ ] Verify Google Video client initialization with valid API key
- [ ] Test video generation with sample prompts
- [ ] Confirm backward compatibility with existing Replicate provider
- [ ] Validate error handling for unsupported providers
- [ ] Check async operation polling mechanism