### PR TITLE
fix: move tempfile import to module level in Google video provider

### DIFF
--- a/src/celeste_video_generation/providers/google.py
+++ b/src/celeste_video_generation/providers/google.py
@@ -1,4 +1,5 @@
 import asyncio
+import tempfile
 from typing import Any
 
 from celeste_core import AIResponse, Provider, VideoArtifact
@@ -28,8 +29,6 @@ class GoogleVideoClient(BaseVideoClient):
             return types.Image.from_file(location=image.path)
         elif image.data:
             # For byte data, save to temp file and use from_file
-            import tempfile
-
             # Detect file extension from image data
             ext = ".jpg"  # default
             if image.data.startswith(b"\x89PNG"):


### PR DESCRIPTION
## Summary
- Moved `tempfile` import from within method to module level
- Improves code organization and follows Python best practices
- Ensures consistency with other imports in the module

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Verify Google video generation still works correctly with image-to-video functionality
- [ ] Ensure tempfile functionality works as expected when processing byte data

🤖 Generated with [Claude Code](https://claude.ai/code)