### PR TITLE
Pass duration and config options to Google video generation

### DIFF
--- a/src/celeste_video_generation/providers/google.py
+++ b/src/celeste_video_generation/providers/google.py
@@ -47,13 +47,20 @@ class GoogleVideoClient(BaseVideoClient):
         self,
         prompt: str,
         image: ImageArtifact | None = None,
-        **kwargs: Any,  # noqa: ARG002
+        **kwargs: Any,
     ) -> AIResponse[list[VideoArtifact]]:
+        # Build optional video generation config
+        config_params: dict[str, Any] = dict(kwargs)
+        if "duration" in config_params:
+            config_params["duration_seconds"] = config_params.pop("duration")
+        config = types.GenerateVideosConfig(**config_params) if config_params else None
+
         # Start video generation
         operation = await self.client.aio.models.generate_videos(
             model=self.model,
             prompt=prompt,
             image=self._prepare_image(image),
+            config=config,
         )
 
         # Poll the operation status until the video is ready


### PR DESCRIPTION
## Summary
- allow callers to specify duration and other config options for Google's video generation API
- forward all keyword args into `GenerateVideosConfig` so Google API honors requested settings

## Testing
- `ruff format src/celeste_video_generation/providers/google.py`
- `ruff check src/celeste_video_generation/providers/google.py --fix`
- `python -m py_compile src/celeste_video_generation/providers/google.py`
- `mypy src/celeste_video_generation/providers/google.py`
- `uv run pre-commit run --files src/celeste_video_generation/providers/google.py` *(failed: tunnel error: unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_68c1440486ec832c909d6c68a7f5f296